### PR TITLE
Adding basic auth as an alternative security mechanism

### DIFF
--- a/src/main/mule/common.xml
+++ b/src/main/mule/common.xml
@@ -7,10 +7,24 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	<flow name="metrics-framework-common-set-auth-vars-from-headers" doc:id="03e16ef6-6fec-48ef-8401-aacdcb0c682b">
 		<set-variable value='#[attributes.headers."X-ANYPNT-ORG-ID"]' doc:name="Set Master Org Id Variable" doc:id="759131f5-05d4-4428-95ce-b7b9fe76da0d"
 			variableName="masterOrgId" />
-		<set-variable value='#[attributes.headers."X-ANYPNT-USERNAME"]' doc:name="Set Username Variable" doc:id="ffbebe02-8320-41e8-a5dc-ea6a645e0d11"
-			variableName="username" />
-		<set-variable value='#[attributes.headers."X-ANYPNT-PASSWORD"]' doc:name="Set Password Variable" doc:id="44ded1cf-5af3-4631-867a-410963d238c8"
-			variableName="password" />
+		<choice doc:name="Choice" doc:id="6f11cbbe-3971-478b-9c6c-188890c59880" >
+			<when expression="#[sizeOf(attributes.headers.Authorization) &gt; 0]">
+				<set-variable value='#[%dw 2.0
+import * from dw::core::Binaries
+output application/java
+---
+(fromBase64((attributes.headers.Authorization default "") replace "Basic " with "") as String splitBy ":")[0]]' doc:name="Set Username Variable from Basic Auth" doc:id="9008b539-d718-4448-8cc7-07ea0cecdca5" variableName="username" />
+				<set-variable value='#[%dw 2.0
+import * from dw::core::Binaries
+output application/java
+---
+(fromBase64((attributes.headers.Authorization default "") replace "Basic " with "") as String splitBy ":")[1]]' doc:name="Set Password Variable from Basic Auth" doc:id="baab28c4-b866-4974-aff8-90f24be652c0" variableName="password" />
+			</when>
+			<otherwise >
+				<set-variable value='#[attributes.headers."X-ANYPNT-USERNAME"]' doc:name="Set Username Variable" doc:id="ffbebe02-8320-41e8-a5dc-ea6a645e0d11" variableName="username" />
+				<set-variable value='#[attributes.headers."X-ANYPNT-PASSWORD"]' doc:name="Set Password Variable" doc:id="44ded1cf-5af3-4631-867a-410963d238c8" variableName="password" />
+			</otherwise>
+		</choice>
 	</flow>
 	
 	<flow name="metrics-framework-common-set-auth-vars-from-properties" doc:id="bcd8192b-7a75-45a5-963e-6c98065b3e71">

--- a/src/main/resources/api/metrics-framework-api.raml
+++ b/src/main/resources/api/metrics-framework-api.raml
@@ -5,12 +5,30 @@ description: Metrics Framework API to obtain and generate operational and busine
 version: v1
 protocols: 
   - HTTPS
-
+  
+securedBy: [basic-auth, headers-auth]
+securitySchemes:
+  basic-auth:
+    description: This API supports Basic Authentication. This mechanism is mandatory if the password contains special characters.
+    type: Basic Authentication
+  headers-auth:
+    description: This API supports Authentication based on custom headers.
+    displayName: Headers Authentication
+    type: x-custom
+    describedBy:
+      headers:
+        X-ANYPNT-USERNAME:
+          description: |
+            Receives the username used when login to Anypoint Platform.
+          type: string
+        X-ANYPNT-PASSWORD:
+          description: |
+            Receives a text/plain password used when login to Anypoint Platform. 
+          type: string
+       
 /platform-metrics:
   get:
     headers:
-      X-ANYPNT-USERNAME: string
-      X-ANYPNT-PASSWORD: string
       X-ANYPNT-ORG-ID: string
     queryParameters:
       raw:
@@ -24,8 +42,6 @@ protocols:
   /load:
     post:
       headers:
-        X-ANYPNT-USERNAME: string
-        X-ANYPNT-PASSWORD: string
         X-ANYPNT-ORG-ID: string 
       body:
         application/json:
@@ -39,8 +55,6 @@ protocols:
 /business-metrics:
   get:
     headers:
-      X-ANYPNT-USERNAME: string
-      X-ANYPNT-PASSWORD: string
       X-ANYPNT-ORG-ID: string
     queryParameters:
       developAPIHistoricTime:
@@ -65,8 +79,6 @@ protocols:
   /load:
     post:
       headers:
-        X-ANYPNT-USERNAME: string
-        X-ANYPNT-PASSWORD: string
         X-ANYPNT-ORG-ID: string
       body:
         application/json:


### PR DESCRIPTION
This pull request comprises the followig changes:

1 - Adding new auth mechanism based on Basic Auth. This is necessary given the limitation of APIKit router when dealing with headers containing some special characters. The other security scheme was not deprecated. Both mechanism are supported.
![Auth-List](https://user-images.githubusercontent.com/50634447/69500848-a3fc3e80-0edd-11ea-8277-dbf585d7f12c.png)

2 - API Spec code stylization. Defining securitySchemes containing the auth headers instead of defining these for each resource. Adding descriptions too.
![RAML-Changes](https://user-images.githubusercontent.com/50634447/69500851-ad85a680-0edd-11ea-92da-b263654312db.png)


3 - Adding choice to common.xml/metrics-framework-common-set-auth-vars-from-headers to decide whether to decrypt credentials when using Basic Auth (b64) or to use custom headers.
![Login-Ok-http200](https://user-images.githubusercontent.com/50634447/69500852-b4141e00-0edd-11ea-8b09-e5efc6b75e5b.png)

todo:
- Add more granularity to the RAML spec, externalizing in types, providing examples and standardizing responses.
- Add a third auth mechanism -No Auth- for those cases when the appplication provides the credentials through parameters file (use secured properties file)
