### PR TITLE
Issue #107 - Fix cannot coerce array as string to object

### DIFF
--- a/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
+++ b/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
@@ -5,4 +5,4 @@ output application/java
 if (vars.aggregatedAPIPayload == null) 
 	payload
 else 
-	(vars.aggregatedAPIPayload update  "assets" with ({([vars.aggregatedAPIPayload.assets,payload.assets])}))
+	(vars.aggregatedAPIPayload update  "assets" with (vars.aggregatedAPIPayload.assets ++ payload.assets))


### PR DESCRIPTION
```
import * from dw::util::Values
output application/java
---
if (vars.aggregatedAPIPayload == null) 
	payload
else 
	(vars.aggregatedAPIPayload update  "assets" with ({([vars.aggregatedAPIPayload.assets,payload.assets])}))
".Route 5: Caught exception in Exception Strategy: "Cannot coerce Array { class: java.util.ArrayList } ([{audit: {created: {date: "2021-06-09T13:16:27.518Z" as String {class: "java....) to Object

8| 	(vars.aggregatedAPIPayload update  "assets" with ({([vars.aggregatedAPIPayload.assets,payload.assets])}))
```