### PR TITLE
Added secure properties list to mule-artifact.json

### DIFF
--- a/mule-artifact.json
+++ b/mule-artifact.json
@@ -1,1 +1,30 @@
-{"minMuleVersion":"4.4.0"}
+{
+	"secureProperties": [
+		"auth.orgId",
+		"auth.username",
+		"auth.password",
+		"auth.clientId",
+		"auth.clientSecret",
+		"ignoreLists.organizations",
+		"ignoreLists.environments",
+		"splunk.token",
+		"elk.user",
+		"elk.password",
+		"mongodb.username",
+		"mongodb.password",
+		"sdlc.confluence.user",
+		"sdlc.confluence.token",
+		"sdlc.bitbucket.user",
+		"sdlc.bitbucket.token",
+		"sdlc.jira.user",
+		"sdlc.jira.token",
+		"sdlc.jenkins.user",
+		"sdlc.jenkins.token",
+		"sdlc.splunk.user",
+		"sdlc.splunk.password",
+		"sfdc.username",
+		"sfdc.password",
+		"sfdc.securityToken"
+	],
+	"minMuleVersion":"4.4.0"
+}


### PR DESCRIPTION
If the application needs to be used in poller mode, all required properties can be set in Runtime Manager to avoid making changes in the code. In the case of secure properties, they should be hidden in the properties tab of the application settings.
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/2286958/165574785-9834d73d-cf9a-4ee6-aa49-553afb9d3025.png">
