### PR TITLE
Fix for incorrect variable rawData

### DIFF
--- a/src/main/mule/common.xml
+++ b/src/main/mule/common.xml
@@ -71,9 +71,15 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 			<ee:message >
 			</ee:message>
 			<ee:variables >
-				<ee:set-variable resource="dw/common/set-raw-data-from-props-var.dwl" variableName="rawData" />
 				<ee:set-variable resource="dw/common/set-collectors-from-props-var.dwl" variableName="collectors" />
 				<ee:set-variable resource="dw/common/set-loader-details-from-props-var.dwl" variableName="loaderDetails" />
+			</ee:variables>
+		</ee:transform>
+		<ee:transform doc:name="Set vars.rawData" doc:id="c17561ae-3b21-47fe-b770-0dd4b32d1dcb">
+			<ee:message>
+			</ee:message>
+			<ee:variables >
+				<ee:set-variable resource="dw/common/set-raw-data-from-props-var.dwl" variableName="rawData" />
 			</ee:variables>
 		</ee:transform>
 	</flow>

--- a/src/main/resources/application-types.xml
+++ b/src/main/resources/application-types.xml
@@ -3,4 +3,5 @@
   <types:catalog/>
   <types:enrichment select="#dfb8458d-858f-41ae-a463-a48351ac21ff"/>
   <types:enrichment select="#b796dbcd-0872-4af7-9368-f8f4d08521a9"/>
+  <types:enrichment select="#892773d6-5f6f-432d-af3e-03f133a2fb7a"/>
 </types:mule>


### PR DESCRIPTION
The variable rawData was set in the same Transform Message component as the variable loaderDetails, on which the DataWeave for rawData depends. Thus vars.rawData was not set correctly.